### PR TITLE
Added css to line up SVG icons in the sidebar

### DIFF
--- a/src/fsolauncher_ui/fsolauncher.css
+++ b/src/fsolauncher_ui/fsolauncher.css
@@ -179,6 +179,11 @@ block {
   margin-top: -5px;
 }
 
+#sidebar svg[class$="-icon"] {
+  margin-left: 6px;
+  margin-right: 7px;
+}
+
 div#splash {
   position: fixed;
   top: 0;


### PR DESCRIPTION
# Related Issue
- https://github.com/ItsSim/fsolauncher/issues/29

# Proposed Changes
Explain your changes here:
- Added CSS to pull the SVG in line with the other icons.
- I've tried to make it generic in case any more SVG icons are added, but depending on the object side the margins may need slightly tweaking (or standardize the SVG icon widths and heights)


# Code Checklist 
- [N] Tested on supported platforms (Windows, macOS). (WIndows only - shouldn't be an issue however as it is handled by the rendering engine)
- [Y] Code follows the [Code Style](https://github.com/ItsSim/fsolauncher/wiki/Code-Style) guidelines.
