### PR TITLE
Add refresh button for home tab feeds.

### DIFF
--- a/src/fsolauncher_ui/client.js
+++ b/src/fsolauncher_ui/client.js
@@ -237,7 +237,14 @@ var setCurrentPage;
     console.log( 'Fetching news...' );
     var $rssUrl     = $( 'body' ).getAttribute( 'rss' );
     var $didYouKnow = $( '#did-you-know' );
+    var $rss        = $( '#rss' );
     var $spinner    = $( '#rss-loading' );
+
+    $( '#refresh-home-button' ).setAttribute( 'disabled', true );
+    $( '#refresh-home-button' ).style.filter = 'brightness(0.5)';
+    $didYouKnow.style.display = 'none';
+    $rss.style.display = 'none';
+    $spinner.style.display = 'block';
 
     try {
       await loadTwitter();
@@ -249,10 +256,16 @@ var setCurrentPage;
       if( ! errors ) {
         hasAlreadyLoaded = true;
       }
-      $didYouKnow.style.display = 'block';
-      $spinner.style.display    = 'none';
 
-     $( '#rss .alt-content' ).style.display = errors ? 'block' : 'none';
+      // Short pause before displaying feed to allow display to render correctly.
+
+      setTimeout( () => {
+        $didYouKnow.style.display = 'block';
+        $rss.style.display = 'block';
+        $spinner.style.display    = 'none';
+      }, 500 );
+
+      $( '#rss .alt-content' ).style.display = errors ? 'block' : 'none';
 
       if( errors || ! response ) {
         return console.log( 'RSS Failed:', errors, response );
@@ -302,6 +315,9 @@ var setCurrentPage;
         console.error( 'An error ocurred getting news:', error );
         parseRss( error, null )
       } );
+
+      // Re-enable refresh button after 3 seconds.
+      setTimeout( () => { $( '#refresh-home-button' ).removeAttribute( 'disabled' ), $( '#refresh-home-button' ).style.filter = 'brightness(1)' }, 3000 );
   }
 
   /**
@@ -779,6 +795,7 @@ var setCurrentPage;
    */
   addEventListener( '.launch',                  'click',       () => sendToMain( 'PLAY' ) );
   addEventListener( '.launch',                  'contextmenu', () => sendToMain( 'PLAY', true ) );
+  addEventListener( '#refresh-home-button',     'click',       () => fetchNews() );
   addEventListener( '#simitone-play-button',    'click',       () => sendToMain( 'PLAY_SIMITONE' ) );
   addEventListener( '#simitone-play-button',    'contextmenu', () => sendToMain( 'PLAY_SIMITONE', true ) );
   addEventListener( '#full-install-button',     'click',       () => sendToMain( 'FULL_INSTALL' ) );

--- a/src/fsolauncher_ui/fsolauncher.pug
+++ b/src/fsolauncher_ui/fsolauncher.pug
@@ -68,6 +68,9 @@ html(class=PLATFORM + ' ' + LANGCODE)
             #content
                 #home-page.page(style='display:none')
                     h1.jumbotron
+                        button#refresh-home-button.turbo-transparent(style='margin-top:-10px;float:right')
+                            i.material-icons.left(style='margin-top:-2px') refresh
+                            |  #{REFRESH_HOME_BTN}
                         span #{HOME}
                         small #{HOME_DESCR}
                     .page-content(style='position:relative')

--- a/src/fsolauncher_ui/uitext.json
+++ b/src/fsolauncher_ui/uitext.json
@@ -174,6 +174,7 @@
     "NOTIFICATIONS_NONE": "No notifications received yet",
     "PLAY": "PLAY",
     "READ_MORE": "READ MORE",
+    "REFRESH_HOME_BTN": "REFRESH",
     "RETICULATING": "Reticulating Splines...",
     "RSS_URL": "https://freeso.org/feed/",
     "SETTINGS": "SETTINGS",


### PR DESCRIPTION
# Related Issue
- https://github.com/ItsSim/fsolauncher/issues/37

# Proposed Changes
- Add refresh button to home tab to reload news/twitter feeds.
- Add some timers to prevent button spamming, also giving 0.5s for the twitter feed to render correctly before re-displaying and hiding the loading spinner, as refresh looked ugly.

# Additional Info
- Using a setTimer method might not be the best option but works unless anyone can think of a better way to ensure all parts are properly rendered before showing?

# Code Checklist 
(Not applicable to language updates)
- [ Windows only ] Tested on supported platforms (Windows, macOS).
- [ Y ] Code follows the [Code Style](https://github.com/ItsSim/fsolauncher/wiki/Code-Style) guidelines.
![Refresh1](https://user-images.githubusercontent.com/14261788/161404820-5470cbeb-48bd-4bba-b915-f3a7a16fe0ce.png)
![Refresh2](https://user-images.githubusercontent.com/14261788/161404824-3eb4bca7-a908-410f-9bad-e38cdc3fc2bd.png)
