### PR TITLE
Improved Linux SDL Installer

### DIFF
--- a/app/fsolauncher/constants.js
+++ b/app/fsolauncher/constants.js
@@ -22,7 +22,6 @@ const linuxDistro = ( () => {
 } )();
 const isArch = linuxDistro.id === 'arch' || linuxDistro.like === 'arch';
 const isDebian = linuxDistro.id === 'debian' || linuxDistro.like === 'debian';
-const isArm = os.arch().includes('arm');
 const linuxLibPath = ( () => {
   const arch = os.arch();
   switch ( arch ) {
@@ -81,7 +80,7 @@ const version = packageJson.version;
 const defaultRefreshRate = 60;
 const defaultGameLanguage = 'English';
 const dependencies = {
-  'FSO': [ 'TSO', ...( [ 'darwin', 'linux' ].includes( process.platform ) ? [ 'Mono', 'SDL' ] : [ 'OpenAL' ] ) ],
+  'FSO': [ 'TSO', ...( [ 'darwin', 'linux' ].includes( process.platform ) ? [ 'Mono', 'SDL' ] : [ 'OpenAL' ] )],
   'RMS': [ 'FSO' ],
   'MacExtras': [ 'FSO' ],
   'Simitone': ( [ 'darwin', 'linux' ].includes( process.platform ) ) ? [ 'Mono', 'SDL' ] : []
@@ -240,6 +239,5 @@ module.exports = {
   registry,
   linuxDistro,
   isArch,
-  isDebian,
-  isArm
+  isDebian
 };

--- a/app/fsolauncher/constants.js
+++ b/app/fsolauncher/constants.js
@@ -80,7 +80,7 @@ const version = packageJson.version;
 const defaultRefreshRate = 60;
 const defaultGameLanguage = 'English';
 const dependencies = {
-  'FSO': [ 'TSO', ...( [ 'darwin', 'linux' ].includes( process.platform ) ? [ 'Mono', 'SDL' ] : [ 'OpenAL' ] )],
+  'FSO': [ 'TSO', ...( [ 'darwin', 'linux' ].includes( process.platform ) ? [ 'Mono', 'SDL' ] : [ 'OpenAL' ] ) ],
   'RMS': [ 'FSO' ],
   'MacExtras': [ 'FSO' ],
   'Simitone': ( [ 'darwin', 'linux' ].includes( process.platform ) ) ? [ 'Mono', 'SDL' ] : []

--- a/app/fsolauncher/constants.js
+++ b/app/fsolauncher/constants.js
@@ -238,6 +238,7 @@ module.exports = {
   temp,
   registry,
   linuxDistro,
+  linuxLibPath,
   isArch,
   isDebian
 };

--- a/app/fsolauncher/constants.js
+++ b/app/fsolauncher/constants.js
@@ -22,6 +22,7 @@ const linuxDistro = ( () => {
 } )();
 const isArch = linuxDistro.id === 'arch' || linuxDistro.like === 'arch';
 const isDebian = linuxDistro.id === 'debian' || linuxDistro.like === 'debian';
+const isArm = os.arch().includes('arm');
 const linuxLibPath = ( () => {
   const arch = os.arch();
   switch ( arch ) {
@@ -239,5 +240,6 @@ module.exports = {
   registry,
   linuxDistro,
   isArch,
-  isDebian
+  isDebian,
+  isArm
 };

--- a/app/fsolauncher/lib/installers/macextras.js
+++ b/app/fsolauncher/lib/installers/macextras.js
@@ -66,7 +66,7 @@ class MacExtrasInstaller {
    *  Replace MonoGame.Framework.dll.config on Arm Linux
    */
   armPatch() {
-    if ( process.platform == 'linux' && process.arch.startsWith('arm') ) {
+    if ( process.platform == 'linux' && process.arch.startsWith( 'arm' ) ) {
       // This file is relatively small so it's not really worth creating a new file just for it
       fs.writeFileSync( `${this.path}/MonoGame.Framework.dll.config`,
         '<?xml version="1.0" encoding="utf-8"?>\n' +
@@ -74,7 +74,7 @@ class MacExtrasInstaller {
         `  <dllmap dll="SDL2.dll" os="linux" target="${linuxLibPath}/libSDL2-2.0.so.0"/>\n` +
         `  <dllmap dll="soft_oal.dll" os="linux" target="${linuxLibPath}/libopenal.so.1"/>\n` +
         '</configuration>'
-       );
+      );
     }
   }
 

--- a/app/fsolauncher/lib/installers/macextras.js
+++ b/app/fsolauncher/lib/installers/macextras.js
@@ -69,10 +69,10 @@ class MacExtrasInstaller {
     if ( process.platform == 'linux' && process.arch.startsWith('arm') ) {
       // This file is relatively small so it's not really worth creating a new file just for it
       fs.writeFileSync( `${this.path}/MonoGame.Framework.dll.config`,
-        '<?xml version="1.0" encoding="utf-8"?>' +
-        '<configuration>' +
-        `  <dllmap dll="SDL2.dll" os="linux" target="${linuxLibPath}/libSDL2-2.0.so.0"/>` +
-        `  <dllmap dll="soft_oal.dll" os="linux" target="${linuxLibPath}/libopenal.so.1"/>` +
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<configuration>\n' +
+        `  <dllmap dll="SDL2.dll" os="linux" target="${linuxLibPath}/libSDL2-2.0.so.0"/>\n` +
+        `  <dllmap dll="soft_oal.dll" os="linux" target="${linuxLibPath}/libopenal.so.1"/>\n` +
         '</configuration>'
        );
     }

--- a/app/fsolauncher/lib/installers/macextras.js
+++ b/app/fsolauncher/lib/installers/macextras.js
@@ -121,13 +121,11 @@ class MacExtrasInstaller {
   /**
    * Creates all the directories and subfolders in a path.
    *
-   * @param {string} dir The path to create.
-   *
    * @returns {Promise<void>} A promise that resolves when the directory is created.
    */
-  setupDir( dir ) {
+  setupDir() {
     return new Promise( ( resolve, reject ) => {
-      require( 'fs-extra' ).ensureDir( dir, err => {
+      require( 'fs-extra' ).ensureDir( his.path, err => {
         if ( err ) return reject( err );
         resolve();
       } );

--- a/app/fsolauncher/lib/installers/macextras.js
+++ b/app/fsolauncher/lib/installers/macextras.js
@@ -125,7 +125,7 @@ class MacExtrasInstaller {
    */
   setupDir() {
     return new Promise( ( resolve, reject ) => {
-      require( 'fs-extra' ).ensureDir( his.path, err => {
+      require( 'fs-extra' ).ensureDir( this.path, err => {
         if ( err ) return reject( err );
         resolve();
       } );

--- a/app/fsolauncher/lib/installers/macextras.js
+++ b/app/fsolauncher/lib/installers/macextras.js
@@ -68,7 +68,7 @@ class MacExtrasInstaller {
   armPatch() {
     if ( process.platform == 'linux' && process.arch.startsWith('arm') ) {
       // This file is relatively small so it's not really worth creating a new file just for it
-      fs.writeFileSync( `${path}/MonoGame.Framework.dll.config`,
+      fs.writeFileSync( `${this.path}/MonoGame.Framework.dll.config`,
         '<?xml version="1.0" encoding="utf-8"?>' +
         '<configuration>' +
         `  <dllmap dll="SDL2.dll" os="linux" target="${linuxLibPath}/libSDL2-2.0.so.0"/>` +

--- a/app/fsolauncher/lib/installers/sdl.js
+++ b/app/fsolauncher/lib/installers/sdl.js
@@ -2,7 +2,7 @@ const download = require( '../download' );
 const { strFormat, loadDependency } = require( '../utils' );
 /** @type {import('sudo-prompt')} */
 const sudo = loadDependency( 'sudo-prompt' );
-const { resourceCentral, temp, isArch, isArm, linuxLibPath } = require( '../../constants' );
+const { resourceCentral, temp, isArch, isArm, linuxLibPath, appData } = require( '../../constants' );
 const { locale } = require( '../locale' );
 const { symlink } = require( 'fs-extra' );
 

--- a/app/fsolauncher/lib/installers/sdl.js
+++ b/app/fsolauncher/lib/installers/sdl.js
@@ -2,9 +2,8 @@ const download = require( '../download' );
 const { strFormat, loadDependency } = require( '../utils' );
 /** @type {import('sudo-prompt')} */
 const sudo = loadDependency( 'sudo-prompt' );
-const { resourceCentral, temp, isArch, isArm, linuxLibPath, appData } = require( '../../constants' );
+const { resourceCentral, temp, isArch } = require( '../../constants' );
 const { locale } = require( '../locale' );
-const { symlink } = require( 'fs-extra' );
 
 /**
  * Installs SDL on macOS systems.
@@ -75,11 +74,6 @@ class SDLInstaller {
         console.error( `stderr: ${stderr}` );
         resolve();
       } );
-
-      // Seems to be required only for Arm/Arm64 since x86_64 uses vendored version from MacExtras
-      if ( isArm ) {
-        symlink( `${appData}/GameComponents/FreeSO/libSDL2.so`, `${linuxLibPath}/libSDL2.so.0` );
-      }
     } );
   }
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -40,24 +40,6 @@
         "innosetup-compiler": "^6.2.0"
       }
     },
-    "../vendor/electron-custom-notifications": {
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "uuid": "^3.3.2"
-      },
-      "devDependencies": {
-        "@types/node": "^10.11.7",
-        "@types/uuid": "^3.4.4",
-        "electron": "^17.0.0",
-        "typescript": "^3.1.2"
-      }
-    },
-    "../vendor/sudo-prompt": {
-      "name": "@vscode/sudo-prompt",
-      "version": "9.3.1",
-      "license": "MIT"
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -1912,8 +1894,12 @@
       }
     },
     "node_modules/electron-custom-notifications": {
-      "resolved": "../vendor/electron-custom-notifications",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "file:../vendor/electron-custom-notifications",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "^3.3.2"
+      }
     },
     "node_modules/electron-installer-common": {
       "version": "0.10.3",
@@ -6342,8 +6328,10 @@
       }
     },
     "node_modules/sudo-prompt": {
-      "resolved": "../vendor/sudo-prompt",
-      "link": true
+      "name": "@vscode/sudo-prompt",
+      "version": "9.3.1",
+      "resolved": "file:../vendor/sudo-prompt",
+      "license": "MIT"
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
@@ -6708,6 +6696,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -40,6 +40,24 @@
         "innosetup-compiler": "^6.2.0"
       }
     },
+    "../vendor/electron-custom-notifications": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "^3.3.2"
+      },
+      "devDependencies": {
+        "@types/node": "^10.11.7",
+        "@types/uuid": "^3.4.4",
+        "electron": "^17.0.0",
+        "typescript": "^3.1.2"
+      }
+    },
+    "../vendor/sudo-prompt": {
+      "name": "@vscode/sudo-prompt",
+      "version": "9.3.1",
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -1894,12 +1912,8 @@
       }
     },
     "node_modules/electron-custom-notifications": {
-      "version": "1.0.0",
-      "resolved": "file:../vendor/electron-custom-notifications",
-      "license": "ISC",
-      "dependencies": {
-        "uuid": "^3.3.2"
-      }
+      "resolved": "../vendor/electron-custom-notifications",
+      "link": true
     },
     "node_modules/electron-installer-common": {
       "version": "0.10.3",
@@ -6328,10 +6342,8 @@
       }
     },
     "node_modules/sudo-prompt": {
-      "name": "@vscode/sudo-prompt",
-      "version": "9.3.1",
-      "resolved": "file:../vendor/sudo-prompt",
-      "license": "MIT"
+      "resolved": "../vendor/sudo-prompt",
+      "link": true
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
@@ -6696,15 +6708,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {


### PR DESCRIPTION
This PR removes unneeded `libsdl2-dev` dependency for Debian-based systems along with combining `aptInstall()` and `pacmanInstall()` functions into `linuxInstall()` along with symlinking `libSDL2.so` to FreeSO's folder on Arm devices since vendored SDL2 from MacExtras is an `x86_64` library.

Edit: I just realized you can probably point FreeSO to use system libraries by editing `MonoGame.Framework.dll.config`. I'll first check if this fix work and then I'll try the `MonoGame.Framework.dll.config` way.
Edit 2: The SDL2 and OpenAL installers can actually be "removed" for the Linux version since these packages can be set as dependencies which are automatically installed when installing the package.