### PR TITLE
Fix theme reset bug on Linux

### DIFF
--- a/app/fsolauncher/fsolauncher.js
+++ b/app/fsolauncher/fsolauncher.js
@@ -1232,6 +1232,10 @@ class FSOLauncher {
 
   getAppropriateTheme() {
     const shouldBeDark = nativeTheme.shouldUseDarkColors;
+    // Fix for Linux where shouldBeDark randomly changes to false out of the sudden
+    if ( process.platform === 'linux' && nativeTheme.themeSource === 'system' ) {
+      nativeTheme.themeSource = shouldBeDark ? 'dark' : 'light';
+    }
     if ( shouldBeDark && ! this.isDarkMode() ) return 'dark';
     if ( ! shouldBeDark && this.isDarkMode() ) return 'open_beta';
 


### PR DESCRIPTION
# Related Issue
- [[Bug] Theme gets every launch on Linux](https://github.com/ItsSim/fsolauncher/issues/87)

# Proposed Changes
Override `nativeTheme.themeSource` to `light` or `dark` based on the initial `nativeTheme.shouldUseDarkColors` state

# Additional Info
The bug was caused by `nativeTheme.shouldUseDarkColors` randomly going from `true` to `false` without any reasons. For the first few times everything was correct so I'm overriding `nativeTheme.themeSource` from the unpredictable `system`